### PR TITLE
Little improvements

### DIFF
--- a/Factory/UserFactory.php
+++ b/Factory/UserFactory.php
@@ -41,7 +41,7 @@ class UserFactory
         $user->setCommunityVisibilityState($userData['communityvisibilitystate']);
         $user->setProfileState($userData['profilestate']);
         $user->setProfileName($userData['personaname']);
-        $user->setLastLogOff($userData['lastlogoff']);
+        $user->setLastLogOff($userData['lastlogoff'] ?? null);
         $user->setCommentPermission(
             isset($userData['commentpermission']) ? $userData['commentpermission'] : 0
         );

--- a/Http/SteamApiClient.php
+++ b/Http/SteamApiClient.php
@@ -40,7 +40,21 @@ class SteamApiClient
      */
     public function loadProfile(int $steamId)
     {
-        $url = sprintf('%s/ISteamUser/GetPlayerSummaries/v0002/?key=%s&steamids=%s', self::STEAM_API, $this->apiKey, $steamId);
+        $profiles = $this->loadProfiles([$steamId]);
+        $userData = current($profiles);
+        return $userData;
+    }
+
+    /**
+     * @param int[] $steamIds
+     *
+     * @return array
+     *
+     * @throws InvalidApiResponseException
+     */
+    public function loadProfiles(array $steamIds)
+    {
+        $url = sprintf('%s/ISteamUser/GetPlayerSummaries/v0002/?key=%s&steamids=%s', self::STEAM_API, $this->apiKey, implode(',', $steamIds));
 
         $data = json_decode($this->client->get($url)->getBody()->getContents(), true);
 
@@ -48,11 +62,10 @@ class SteamApiClient
             throw new InvalidApiResponseException('The received API response is invalid.');
         }
 
-        $userData = current($data['response']['players']);
-        if (false === $userData) {
-            throw new InvalidApiResponseException('The received API response does not contain a user.');
+        if (count($data['response']['players']) === 0) {
+            throw new InvalidApiResponseException('The received API response does not contain users.');
         }
 
-        return $userData;
+        return $data['response']['players'];
     }
 }

--- a/User/AbstractSteamUser.php
+++ b/User/AbstractSteamUser.php
@@ -2,6 +2,7 @@
 
 namespace Knojector\SteamAuthenticationBundle\User;
 
+use DateTime;
 use Doctrine\ORM\Mapping as ORM;
 use Symfony\Component\Security\Core\User\UserInterface;
 use Symfony\Component\Security\Core\Role\Role;
@@ -40,7 +41,7 @@ abstract class AbstractSteamUser implements SteamUserInterface, UserInterface
     protected $profileName;
 
     /**
-     * @var \DateTime
+     * @var DateTime
      *
      * @ORM\Column(type="datetime")
      */
@@ -82,7 +83,7 @@ abstract class AbstractSteamUser implements SteamUserInterface, UserInterface
     protected $primaryClanId;
 
     /**
-     * @var \DateTime|null
+     * @var DateTime|null
      *
      * @ORM\Column(type="datetime", nullable=true)
      */
@@ -169,7 +170,7 @@ abstract class AbstractSteamUser implements SteamUserInterface, UserInterface
     /**
      * {@inheritdoc}
      */
-    public function getLastLogOff(): \DateTime
+    public function getLastLogOff(): ?DateTime
     {
         return $this->lastLogOff;
     }
@@ -177,9 +178,9 @@ abstract class AbstractSteamUser implements SteamUserInterface, UserInterface
     /**
      * {@inheritdoc}
      */
-    public function setLastLogOff(int $lastLogOff)
+    public function setLastLogOff(?int $lastLogOff)
     {
-        $lastLogOffDate = new \DateTime();
+        $lastLogOffDate = new DateTime();
         $lastLogOffDate->setTimestamp($lastLogOff);
         $this->lastLogOff = $lastLogOffDate;
     }
@@ -267,7 +268,7 @@ abstract class AbstractSteamUser implements SteamUserInterface, UserInterface
     /**
      * {@inheritdoc}
      */
-    public function getJoinDate(): ?\DateTime
+    public function getJoinDate(): ?DateTime
     {
         return $this->joinDate;
     }
@@ -278,7 +279,7 @@ abstract class AbstractSteamUser implements SteamUserInterface, UserInterface
     public function setJoinDate(?int $joinDate): void
     {
         if (null !== $joinDate) {
-            $joinDateDate = new \DateTime();
+            $joinDateDate = new DateTime();
             $joinDateDate->setTimestamp($joinDate);
             $joinDate = $joinDateDate;
         }
@@ -333,7 +334,7 @@ abstract class AbstractSteamUser implements SteamUserInterface, UserInterface
     {
         return;
     }
-    
+
     /**
      * @return array
      */
@@ -354,7 +355,7 @@ abstract class AbstractSteamUser implements SteamUserInterface, UserInterface
         $this->setCommunityVisibilityState($userData['communityvisibilitystate']);
         $this->setProfileState($userData['profilestate']);
         $this->setProfileName($userData['personaname']);
-        $this->setLastLogOff($userData['lastlogoff']);
+        $this->setLastLogOff($userData['lastlogoff'] ?? null);
         $this->setCommentPermission(
             isset($userData['commentpermission']) ? $userData['commentpermission'] : 0
         );

--- a/User/SteamUserInterface.php
+++ b/User/SteamUserInterface.php
@@ -2,6 +2,8 @@
 
 namespace Knojector\SteamAuthenticationBundle\User;
 
+use DateTime;
+
 /**
  * @see https://developer.valvesoftware.com/wiki/Steam_Web_API#GetPlayerSummaries_.28v0002.29
  *
@@ -47,17 +49,17 @@ interface SteamUserInterface
     /**
      * @param string $name
      */
-    public function setProfileName(string  $name);
+    public function setProfileName(string $name);
 
     /**
-     * @return \DateTime
+     * @return DateTime|null
      */
-    public function getLastLogOff(): \DateTime;
+    public function getLastLogOff(): ?DateTime;
 
     /**
      * @param int $lastLogOff
      */
-    public function setLastLogOff(int $lastLogOff);
+    public function setLastLogOff(?int $lastLogOff);
 
     /**
      * @return int
@@ -110,9 +112,9 @@ interface SteamUserInterface
     public function setPrimaryClanId(int $clanId);
 
     /**
-     * @return \DateTime|null
+     * @return DateTime|null
      */
-    public function getJoinDate(): ?\DateTime;
+    public function getJoinDate(): ?DateTime;
 
     /**
      * @param int|null $joinDate


### PR DESCRIPTION
Hi!

I've done two little things:

- SteamApiClient::loadProfiles to be able to load multiple profiles at once. It isn't used by library itself, but it could be helpful in some cases. In my case I must create user profiles (from some group for example) before they enter the site. I could load it through `loadProfile`, but it would be overhead
- lastlogoff is nullable, so is its field. I suppose it's a rare case, but I've faced it