### PR TITLE
added missing dependencies

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -17,9 +17,11 @@
     "symfony/config": "^4.0|^5.0",
     "symfony/dependency-injection": "^4.0|^5.0",
     "symfony/event-dispatcher": "^4.0|^5.0",
+    "symfony/expression-language": "^4.0|^5.0",
     "symfony/framework-bundle": "^4.0|^5.0",
     "symfony/http-client": "^4.0|^5.0",
     "symfony/security-bundle": "^4.0|^5.0",
+    "symfony/routing": "^4.0|^5.0",
     "symfony/validator": "^4.0|^5.0"
   }
 }


### PR DESCRIPTION
symfony/expression-language is required by Assert\Expression annotation in SteamCallback
symfony/routing is required by Route annotation in SteamController