### PR TITLE
raised minimum php version to 7.1.3

### DIFF
--- a/README.md
+++ b/README.md
@@ -122,5 +122,5 @@ Feel free to open an issue or submit a pull request :wink:
 
 ## Requirements
 The bundle requires:
-- PHP 7.0+
+- PHP 7.1.3+
 - Symfony 4/5

--- a/composer.json
+++ b/composer.json
@@ -13,7 +13,7 @@
     "psr-4": { "Knojector\\SteamAuthenticationBundle\\": "" }
   },
   "require": {
-    "php": ">=7.0",
+    "php": ">=7.1.3",
     "symfony/config": "^4.0|^5.0",
     "symfony/dependency-injection": "^4.0|^5.0",
     "symfony/event-dispatcher": "^4.0|^5.0",


### PR DESCRIPTION
I've updated minimum php version because symfony/config package requires php 7.1.3 at least