### PR TITLE
Fixed openid.realm

### DIFF
--- a/Resources/views/button.html.twig
+++ b/Resources/views/button.html.twig
@@ -3,7 +3,7 @@
     <input type="hidden" name="openid.claimed_id" value="http://specs.openid.net/auth/2.0/identifier_select">
     <input type="hidden" name="openid.ns" value="http://specs.openid.net/auth/2.0">
     <input type="hidden" name="openid.mode" value="checkid_setup">
-    <input type="hidden" name="openid.realm" value="{{ app.request.uri }}">
+    <input type="hidden" name="openid.realm" value="{{ app.request.schemeAndHttpHost }}">
     <input type="hidden" name="openid.return_to" value="{{ url('steam_authentication_callback') }}">
     <input type="image" name="submit" src="https://steamcommunity-a.akamaihd.net/public/images/signinthroughsteam/sits_01.png" border="0" alt="Submit">
 </form>


### PR DESCRIPTION
Using `app.request.schemeAndHttpHost` instead of `app.request.uri` prevents a Steam OpenID error that occurs when you try to log in from anywhere else than your website's root page.