### PR TITLE
fix: trying to catch the wrong exception

### DIFF
--- a/README.md
+++ b/README.md
@@ -115,4 +115,4 @@ Feel free to open an issue or submit a pull request :wink:
 ## Requirements
 The bundle requires:
 - PHP 8.0.0+
-- Symfony 4/5/6
+- Symfony 5.3/6

--- a/Subscriber/LoadUserSubscriber.php
+++ b/Subscriber/LoadUserSubscriber.php
@@ -7,7 +7,7 @@ use Knojector\SteamAuthenticationBundle\Event\FirstLoginEvent;
 use Knojector\SteamAuthenticationBundle\Event\PayloadValidEvent;
 use Symfony\Component\EventDispatcher\EventDispatcherInterface;
 use Symfony\Component\EventDispatcher\EventSubscriberInterface;
-use Symfony\Component\Security\Core\Exception\UsernameNotFoundException;
+use Symfony\Component\Security\Core\Exception\UserNotFoundException;
 use Symfony\Component\Security\Core\User\UserProviderInterface;
 
 /**
@@ -38,7 +38,7 @@ class LoadUserSubscriber implements EventSubscriberInterface
 
         try {
             $user = $this->userProvider->loadUserByIdentifier($communityId);
-        } catch (UsernameNotFoundException $e) {
+        } catch (UserNotFoundException $e) {
             $this->eventDispatcher->dispatch(new FirstLoginEvent($communityId), FirstLoginEvent::NAME);
 
             return;

--- a/composer.json
+++ b/composer.json
@@ -14,14 +14,14 @@
   },
   "require": {
     "php": ">=8.0.0",
-    "symfony/config": "^4.0|^5.0|^6.0",
-    "symfony/dependency-injection": "^4.0|^5.0|^6.0",
-    "symfony/event-dispatcher": "^4.0|^5.0|^6.0",
-    "symfony/expression-language": "^4.0|^5.0|^6.0",
-    "symfony/framework-bundle": "^4.0|^5.0|^6.0",
-    "symfony/http-client": "^4.0|^5.0|^6.0",
-    "symfony/security-bundle": "^4.0|^5.0|^6.0",
-    "symfony/routing": "^4.0|^5.0|^6.0",
-    "symfony/validator": "^4.0|^5.0|^6.0"
+    "symfony/config": "^5.3|^6.0",
+    "symfony/dependency-injection": "^5.3|^6.0",
+    "symfony/event-dispatcher": "^5.3|^6.0",
+    "symfony/expression-language": "^5.3|^6.0",
+    "symfony/framework-bundle": "^5.3|^6.0",
+    "symfony/http-client": "^5.3|^6.0",
+    "symfony/security-bundle": "^5.3|^6.0",
+    "symfony/routing": "^5.3|^6.0",
+    "symfony/validator": "^5.3|^6.0"
   }
 }


### PR DESCRIPTION
Fixed trying to catch UsernameNotFoundException which is now removed from Symfony 6 (it is replaced by UserNotFoundException)
This prevents the "FirstLogin" event to be triggered if the user does not exist in the database.