### PR TITLE
Add a method to generate callback verification with the corrected key name pattern

### DIFF
--- a/DTO/SteamCallback.php
+++ b/DTO/SteamCallback.php
@@ -66,4 +66,21 @@ class SteamCallback
 
         return $steamCallback;
     }
+
+    public function getVerificationArray(): array
+    {
+        $verificationArray = [];
+        $verificationArray['openid.ns'] = $this->openid_ns;
+        $verificationArray['openid.mode'] = $this->openid_mode;
+        $verificationArray['openid.op_endpoint'] =$this->openid_op_endpoint;
+        $verificationArray['openid.claimed_id'] =$this->openid_claimed_id;
+        $verificationArray['openid.identity'] =$this->openid_identity;
+        $verificationArray['openid.return_to'] =$this->openid_return_to;
+        $verificationArray['openid.response_nonce'] =$this->openid_response_nonce;
+        $verificationArray['openid.assoc_handle'] =$this->openid_assoc_handle;
+        $verificationArray['openid.signed'] =$this->openid_signed;
+        $verificationArray['openid.sig'] =$this->openid_sig;
+
+        return $verificationArray;
+    }
 }

--- a/Subscriber/ValidateCallbackReceivedSubscriber.php
+++ b/Subscriber/ValidateCallbackReceivedSubscriber.php
@@ -42,7 +42,7 @@ class ValidateCallbackReceivedSubscriber implements EventSubscriberInterface
             'POST',
             self::STEAM_VALIDATION_URL,
             [
-                'body' => (array) $callback
+                'body' => $callback->getVerificationArray()
             ]
         );
 


### PR DESCRIPTION
Callback verification was not working when using openid_. in ValidateCallbackReceivedSubscriber line 45 .
I've added a method to the DTO that returns an array for validation, using the edited key to follow the "openid." pattern instead of "openid_".